### PR TITLE
#24 refactoring create quick match

### DIFF
--- a/src/main/java/com/minsproject/matchpoint/dto/request/QuickMatchCreate.java
+++ b/src/main/java/com/minsproject/matchpoint/dto/request/QuickMatchCreate.java
@@ -1,5 +1,6 @@
 package com.minsproject.matchpoint.dto.request;
 
+import com.minsproject.matchpoint.constant.type.SportType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,5 +11,5 @@ import lombok.Setter;
 public class QuickMatchCreate {
     private Long inviterId;
     private Long inviteeId;
-    private String sportType;
+    private SportType sportType;
 }

--- a/src/main/java/com/minsproject/matchpoint/service/MatchService.java
+++ b/src/main/java/com/minsproject/matchpoint/service/MatchService.java
@@ -30,6 +30,7 @@ public class MatchService {
     private final UserRepository userRepository;
     private final MatchRepository matchRepository;
     private final MatchResultRepository resultRepository;
+    private final SportProfileService sportProfileService;
     private final SportProfileRepository sportProfileRepository;
 
 
@@ -45,10 +46,12 @@ public class MatchService {
     }
 
     public Match createQuickMatch(QuickMatchCreate request) {
-        SportProfile inviter = sportProfileRepository.findById(request.getInviterId()).orElseThrow(() -> new MatchPointException(ErrorCode.PROFILE_NOT_FOUND));
+        SportProfile inviter = sportProfileService.getProfileById(request.getInviterId());
+        SportProfile invitee = sportProfileService.getProfileById(request.getInviteeId());
 
-        SportProfile invitee = sportProfileRepository.findById(request.getInviteeId()).orElseThrow(() -> new MatchPointException(ErrorCode.PROFILE_NOT_FOUND));
-
+        /*
+        TODO: 스포츠타입을 string으로 받는데 이걸 enum으로 받으면 처음부터 존재하는 스포츠타입인지 확인할수있지않을까?
+         */
         boolean hasSportType = Arrays.stream(SportType.values())
                 .filter(sport -> sport.getName().equals(request.getSportType()))
                 .findFirst()
@@ -57,6 +60,10 @@ public class MatchService {
             throw new MatchPointException(ErrorCode.SPORT_NOT_FOUND);
         }
 
+        /*
+        TODO: 2/26/25
+            매칭 신청자와 수락자의 종목이 같은지 검사하는거니까 프로필 엔티티에게 이 역할을 맡겨야할거같다.
+        */
         if (!StringUtils.equals(inviter.getSportType(), request.getSportType())) {
             throw new MatchPointException(ErrorCode.INCORRECT_SPORT_TYPE);
         }

--- a/src/main/java/com/minsproject/matchpoint/service/MatchService.java
+++ b/src/main/java/com/minsproject/matchpoint/service/MatchService.java
@@ -50,17 +50,6 @@ public class MatchService {
         SportProfile invitee = sportProfileService.getProfileById(request.getInviteeId());
 
         /*
-        TODO: 스포츠타입을 string으로 받는데 이걸 enum으로 받으면 처음부터 존재하는 스포츠타입인지 확인할수있지않을까?
-         */
-        boolean hasSportType = Arrays.stream(SportType.values())
-                .filter(sport -> sport.getName().equals(request.getSportType()))
-                .findFirst()
-                .isEmpty();
-        if (hasSportType) {
-            throw new MatchPointException(ErrorCode.SPORT_NOT_FOUND);
-        }
-
-        /*
         TODO: 2/26/25
             매칭 신청자와 수락자의 종목이 같은지 검사하는거니까 프로필 엔티티에게 이 역할을 맡겨야할거같다.
         */


### PR DESCRIPTION
변경사항
1. 초대자와 수락자 정보를 가져오는 역할을 repository가 아닌 sportprofileService로 변경했다.
2. 매칭 생성에 담긴 스포츠 종목을 String에서 enum 타입으로 받는 걸로 변경하고 검증 로직을 제거했다.